### PR TITLE
fix orientation of randomly sampled points

### DIFF
--- a/src/ps/psface.cpp
+++ b/src/ps/psface.cpp
@@ -645,7 +645,7 @@ void PSFace::random_sample_points(
         );
         for (int j = 0; j < 3; ++j) {
             samples(i, j) = point.coord[j];
-            samples(i, j + 3) = normal.coord[j];
+            samples(i, j + 3) = orientation ? normal.coord[j] : -normal.coord[j];
         }
     }
 


### PR DESCRIPTION
This is the exact same fix as I did for the standard UV samples, but it had yet to be applied to the random samples in `PSFace::randomly_sample_points()`.